### PR TITLE
Turn org members to list

### DIFF
--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -640,9 +640,9 @@ class GitHubBase(GitBase):
             current_invites = {}
 
         # Loop through target users
-        for member, member_props in target_members.items():
-            login = member.lower()
-            target_role = member_props.get('role', 'member').lower()
+        for member in target_members:
+            login = member['login'].lower()
+            target_role = member['role'].lower()
             msg = None
             try:
                 if login not in current_members:

--- a/plugins/modules/members.py
+++ b/plugins/modules/members.py
@@ -49,7 +49,7 @@ class MembersModule(GitHubBase):
         for owner, owner_dict in self.get_members().items():
             (org_changed, status[owner]) = self._manage_org_members(
                 owner,
-                {x['login']: x for x in owner_dict['present'].get('users', [])},
+                owner_dict['present'].get('users', []),
                 False,
                 self.ansible.check_mode
             )

--- a/tests/integration/targets/github_org_members/tasks/main.yaml
+++ b/tests/integration/targets/github_org_members/tasks/main.yaml
@@ -4,12 +4,10 @@
       token: "{{ token }}"
       organization: "{{ test_org }}"
       members:
-        gtema:
+        - login: gtema
           role: "owner"
-        g2tema:
+        - login: g2tema
           role: "member"
-        otcbot:
-          role: "owner"
 
   block:
     - name: Apply users - check mode


### PR DESCRIPTION
Switch back to using list for defining members. In the teams we need
that and it make sense to keep similar interface.
