### PR TITLE
Do not fail if current branch restrictions are empty

### DIFF
--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -989,6 +989,8 @@ class GitHubBase(GitBase):
                 ('teams', 'slug'),
                 ('apps', 'slug')
             ]:
+                if not current_restrictions or case[0] not in current_restrictions:
+                    return True
                 if (
                     set(
                         [x[case[1]] for x in current_restrictions[case[0]]]


### PR DESCRIPTION
Improve check of the current branch protections not to fail when we try to check empty current restriction