### PR TITLE
Replace ansible-base with ansible-core

### DIFF
--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -738,7 +738,7 @@ class GitHubBase(GitBase):
             status[login] = 'Invite cancelled'
 
         # Report current members that are not in the target state
-        for member, _ in current_members.items():
+        for member, ignore in current_members.items():
             if not exclusive:
                 status[member] = 'Not Managed'
             else:
@@ -857,13 +857,13 @@ class GitHubBase(GitBase):
         # In the exclusive mode drop maintainers and members not present in the
         # target state
         if exclusive:
-            for member, _ in current_members.items():
+            for member, ignore in current_members.items():
                 changed = True
                 if not check_mode:
                     self.delete_team_member(
                         owner, slug, member)
                 status['members'][member] = 'removed'
-            for member, _ in current_maintainers.items():
+            for member, ignore in current_maintainers.items():
                 changed = True
                 if not check_mode:
                     self.delete_team_member(

--- a/plugins/modules/github_org_repository.py
+++ b/plugins/modules/github_org_repository.py
@@ -408,7 +408,9 @@ class GHOrgRepositoryModule(GitHubBase):
                         require_code_owner_reviews=dict(
                             type='bool', default=True),
                         required_approving_review_count=dict(type='int',
-                                                             choices=range(1, 6))
+                                                             choices=[
+                                                                 1, 2, 3,
+                                                                 4, 5])
                     )
                 ),
                 restrictions=dict(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible-base
+ansible-core
 ansible-lint==5.4.0
 pycodestyle==2.6.0
 flake8==3.8.4


### PR DESCRIPTION
In test requirements we still install ansible-base, but it now conflicts
with other parts coming from ansible-core that we also install.
