### PR TITLE
Join docstrings

### DIFF
--- a/plugins/modules/github_org_repository.py
+++ b/plugins/modules/github_org_repository.py
@@ -156,10 +156,8 @@ options:
             * pull - can pull, but not push to or administer this repository.
             * push - can pull and push, but not administer this repository.
             * admin - can pull, push and administer this repository.
-            * maintain - Recommended for project managers who need to manage the
-              repository without access to sensitive or destructive actions.
-            * triage - Recommended for contributors who need to proactively
-              manage issues and pull requests without write access.
+            * maintain - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+            * triage - Recommended for contributors who need to proactively manage issues and pull requests without write access.
         type: str
         choices: [pull, push, admin, maintain, triage]
         default: pull
@@ -181,10 +179,8 @@ options:
             * pull - can pull, but not push to or administer this repository.
             * push - can pull and push, but not administer this repository.
             * admin - can pull, push and administer this repository.
-            * maintain - Recommended for project managers who need to manage the
-              repository without access to sensitive or destructive actions.
-            * triage - Recommended for contributors who need to proactively
-              manage issues and pull requests without write access.
+            * maintain - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+            * triage - Recommended for contributors who need to proactively manage issues and pull requests without write access.
 
         type: str
         choices: [pull, push, admin, maintain, triage]


### PR DESCRIPTION
For some reason splitted item docstring start producing wrong
indentation for sphinx. At least eliminate this for now while search for
the real root cause is going to start.
