### PR TITLE
fix paging for repo collaborators and improve output

### DIFF
--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -802,7 +802,9 @@ class GitHubBase(GitBase):
                     maintainers=target.get('maintainer', [])
                 )
                 if current is None:
-                    raise RuntimeError(f"Unable to create team: {slug} : {target}")
+                    self.save_error(f"Unable to create team: {slug} / {target} with "
+                                    f"maintainers : {', '.join(target.get('maintainer', []))} "
+                                    "(all maintainers must be completely onboarded)")
                 slug = current['slug']
             else:
                 is_existing = False

--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -223,7 +223,9 @@ class GitHubBase(GitBase):
                 if key in info:
                     error_data[key] = info[key]
 
-            self.save_error(f"{error_msg}: {error_data}")
+            error_data["response"] = response or "no response"
+            error_data["body"] = body or "no body"
+            self.save_error(f"request failed {error_msg}: {error_data}")
         elif status == 404 and ignore_missing:
             return None
         if status == 204:
@@ -232,9 +234,11 @@ class GitHubBase(GitBase):
             return json.loads(body)
 
     def paginated_request(self, url, headers=None, timeout=15, **kwargs):
+
         if not url.startswith('http'):
             url = f"{self.gh_url}/{url}"
 
+        result = []
         while url:
             content, response, info = self._request(
                 method='GET',
@@ -246,21 +250,23 @@ class GitHubBase(GitBase):
                 break
 
             url = get_links(response.headers).get("next", {}).get("url")
+            fetched_items = json.loads(content)
+            for item in fetched_items:
+                result.append(item)
 
-            yield from json.loads(content)
+        return result
 
     def get_owner_teams(self, owner):
         """Get Team information"""
-        rsp = self.paginated_request(
-            method='GET',
+        return self.paginated_request(
             url=f'orgs/{owner}/teams',
+            error_msg=f"Cannot fetch teams for {owner}"
         )
-        return rsp
 
     def get_team(self, owner, name, ignore_missing=False):
         return self.request(
             url=f"orgs/{owner}/teams/{name}",
-            error_msg="Error fetching {owner}/{team} team",
+            error_msg=f"Error fetching {owner}/{name} team",
             ignore_missing=ignore_missing
         )
 
@@ -319,7 +325,7 @@ class GitHubBase(GitBase):
             method='GET',
             url=(f"orgs/{owner}/"
                  f"teams/{team}/members?role={role}"),
-            error_msg=f"Cannot fetch team {team}@{owner} {role}s"
+            error_msg=f"Cannot fetch team {team}@{owner} for role {role}"
         )
 
     def get_team_repo_permissions(self, owner, team, repo):
@@ -570,7 +576,7 @@ class GitHubBase(GitBase):
 
     def get_repo_collaborators(self, owner, repo, affiliation='direct'):
         """Get repo collaborators"""
-        return self.request(
+        return self.paginated_request(
             method='GET',
             url=(f"repos/{owner}/{repo}/collaborators?affiliation={affiliation}"),
             error_msg=f"Cannot fetch repo {owner}/{repo} collaborators"
@@ -782,6 +788,7 @@ class GitHubBase(GitBase):
         is_existing = True
         team_status = 'unchanged'
         if not current:
+
             # Create new team
             changed = True
             team_status = 'created'
@@ -794,6 +801,8 @@ class GitHubBase(GitBase):
                     parent=target.get('parent'),
                     maintainers=target.get('maintainer', [])
                 )
+                if current is None:
+                    raise RuntimeError(f"Unable to create team: {slug} : {target}")
                 slug = current['slug']
             else:
                 is_existing = False
@@ -1120,6 +1129,23 @@ class GitHubBase(GitBase):
         owner = kwargs.pop('owner')
         repo_name = kwargs.pop('name')
         current_repo = current if current else self.get_repo(owner, repo_name, ignore_missing=True)
+
+        # Rework the provided settings
+        # The Github API
+        # (https://docs.github.com/de/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection)
+        # describes that you have to set the value to "null" to completely disable restrictions in the org
+        # Due to the fact that the Ansible parameter validation specified in github_org_repository.py specifies
+        # that this value needs to be a dict, the traditional way to set this value to "null"  in the yaml file
+        # is not valid anymore, therefore the flag allow_org_members can be used to achieve this
+        new_branch_protections = []
+        for branch_protection in kwargs['branch_protections']:
+            if branch_protection["restrictions"].get("allow_org_members", False):
+                branch_protection["restrictions"] = None
+            if "allow_org_members" in branch_protection:
+                del branch_protection["restrictions"]["allow_org_members"]
+            new_branch_protections.append(branch_protection)
+        kwargs['branch_protections'] = new_branch_protections
+
         if not current_repo:
             changed = True
             if not check_mode:

--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -1129,23 +1129,6 @@ class GitHubBase(GitBase):
         owner = kwargs.pop('owner')
         repo_name = kwargs.pop('name')
         current_repo = current if current else self.get_repo(owner, repo_name, ignore_missing=True)
-
-        # Rework the provided settings
-        # The Github API
-        # (https://docs.github.com/de/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection)
-        # describes that you have to set the value to "null" to completely disable restrictions in the org
-        # Due to the fact that the Ansible parameter validation specified in github_org_repository.py specifies
-        # that this value needs to be a dict, the traditional way to set this value to "null"  in the yaml file
-        # is not valid anymore, therefore the flag allow_org_members can be used to achieve this
-        new_branch_protections = []
-        for branch_protection in kwargs['branch_protections']:
-            if branch_protection["restrictions"].get("allow_org_members", False):
-                branch_protection["restrictions"] = None
-            if "allow_org_members" in branch_protection:
-                del branch_protection["restrictions"]["allow_org_members"]
-            new_branch_protections.append(branch_protection)
-        kwargs['branch_protections'] = new_branch_protections
-
         if not current_repo:
             changed = True
             if not check_mode:

--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -234,11 +234,9 @@ class GitHubBase(GitBase):
             return json.loads(body)
 
     def paginated_request(self, url, headers=None, timeout=15, **kwargs):
-
         if not url.startswith('http'):
             url = f"{self.gh_url}/{url}"
 
-        result = []
         while url:
             content, response, info = self._request(
                 method='GET',
@@ -250,11 +248,8 @@ class GitHubBase(GitBase):
                 break
 
             url = get_links(response.headers).get("next", {}).get("url")
-            fetched_items = json.loads(content)
-            for item in fetched_items:
-                result.append(item)
 
-        return result
+            yield from json.loads(content)
 
     def get_owner_teams(self, owner):
         """Get Team information"""
@@ -325,7 +320,7 @@ class GitHubBase(GitBase):
             method='GET',
             url=(f"orgs/{owner}/"
                  f"teams/{team}/members?role={role}"),
-            error_msg=f"Cannot fetch team {team}@{owner} for role {role}"
+            error_msg=f"Cannot fetch team {team}@{owner} with role {role}"
         )
 
     def get_team_repo_permissions(self, owner, team, repo):

--- a/plugins/modules/github_org_repository.py
+++ b/plugins/modules/github_org_repository.py
@@ -291,6 +291,12 @@ options:
           and team restrictions are only available for organization-owned repositories.
         type: dict
         suboptions:
+          allow_org_members:
+            description: |
+              Set to true if you want to allow all org to have push access.
+              (in that case all other restrictions are ignored)
+            type: bool
+            default: False
           users:
             description: |
               The list of user logins with push access.
@@ -308,6 +314,7 @@ options:
               The list of app slugs with push access.
             type: list
             elements: str
+            default: []
       required_linear_history:
         description: |
           Enforces a linear commit Git history, which prevents anyone from
@@ -428,9 +435,10 @@ class GHOrgRepositoryModule(GitHubBase):
                 restrictions=dict(
                     type='dict',
                     options=dict(
+                        allow_org_members=dict(type='bool', default=False),
                         users=dict(type='list', elements='str', default=[]),
                         teams=dict(type='list', elements='str', default=[]),
-                        apps=dict(type='list', elements='str')
+                        apps=dict(type='list', elements='str', default=[])
                     )
                 )
             )

--- a/plugins/modules/github_org_repository.py
+++ b/plugins/modules/github_org_repository.py
@@ -291,12 +291,6 @@ options:
           and team restrictions are only available for organization-owned repositories.
         type: dict
         suboptions:
-          allow_org_members:
-            description: |
-              Set to true if you want to allow all org to have push access.
-              (in that case all other restrictions are ignored)
-            type: bool
-            default: False
           users:
             description: |
               The list of user logins with push access.
@@ -435,7 +429,6 @@ class GHOrgRepositoryModule(GitHubBase):
                 restrictions=dict(
                     type='dict',
                     options=dict(
-                        allow_org_members=dict(type='bool', default=False),
                         users=dict(type='list', elements='str', default=[]),
                         teams=dict(type='list', elements='str', default=[]),
                         apps=dict(type='list', elements='str', default=[])

--- a/plugins/modules/github_org_repository.py
+++ b/plugins/modules/github_org_repository.py
@@ -308,7 +308,6 @@ options:
               The list of app slugs with push access.
             type: list
             elements: str
-            default: []
       required_linear_history:
         description: |
           Enforces a linear commit Git history, which prevents anyone from
@@ -431,7 +430,7 @@ class GHOrgRepositoryModule(GitHubBase):
                     options=dict(
                         users=dict(type='list', elements='str', default=[]),
                         teams=dict(type='list', elements='str', default=[]),
-                        apps=dict(type='list', elements='str', default=[])
+                        apps=dict(type='list', elements='str')
                     )
                 )
             )


### PR DESCRIPTION
The current implementation fails when the maximum page size of a api request is exceeded. See SovereignCloudStack/github-manager#184