### PR TITLE
Bugfix: Ignore the 'default_branch' option

### DIFF
--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -225,10 +225,10 @@ class GitHubBase(GitBase):
 
             error_data["response"] = response or "no response"
             error_data["response_body"] = body or "no body"
-            error_data["request_url"] =  url
-            error_data["request_method"] =  method
+            error_data["request_url"] = url
+            error_data["request_method"] = method
             if 'json' in kwargs:
-                error_data["request_body"] =  kwargs['json'] or 'no body'
+                error_data["request_body"] = kwargs['json'] or 'no body'
 
             self.save_error(f"request failed {error_msg}: {error_data}")
         elif status == 404 and ignore_missing:
@@ -1138,7 +1138,6 @@ class GitHubBase(GitBase):
         # Therefore we remove this option in that case.
         if current_repo['size'] == 0:
             del kwargs['default_branch']
-
 
         if not current_repo:
             changed = True

--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -1138,6 +1138,7 @@ class GitHubBase(GitBase):
         # Therefore we remove this option in that case.
         if current_repo['size'] == 0:
             del kwargs['default_branch']
+            self.ansible.warn(f"Repo {repo_name} does not yet have any branches or commits, cannot set the default branch")
 
         if not current_repo:
             changed = True


### PR DESCRIPTION
When specifying a default branch on a repository which is still empty, the execution fails with the following error message:
'Cannot update default branch for an empty repository. Please init the repository and push first'

This change avoids that users have to debug this problem and/or create new repositories in three steps (1. ‘create repo PR’, 2. add branch , 3. ‘set default branch’ PR).

Secondly this change adds a bit more detailed error-debug-output to simplify
debugging situations.
